### PR TITLE
BiometricScheduler: Check if operation is finished before cancelling

### DIFF
--- a/services/core/java/com/android/server/biometrics/sensors/BiometricScheduler.java
+++ b/services/core/java/com/android/server/biometrics/sensors/BiometricScheduler.java
@@ -264,7 +264,7 @@ public class BiometricScheduler {
 
     protected void startNextOperationIfIdle() {
         if (mCurrentOperation != null) {
-            if(mCancel) {
+            if(mCancel && !mCurrentOperation.isFinished()) {
                Slog.v(getTag(), "Not idle, cancelling current operation: " + mCurrentOperation);
 	       mCurrentOperation.cancel(mHandler, mInternalCallback);
             } else {


### PR DESCRIPTION
We can't cancel an operation that has already finished
java.lang.IllegalStateException: cancel: mState must not be 5